### PR TITLE
Fix storage account creation

### DIFF
--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -268,7 +268,8 @@ exports.getOrCreateBlobStorage = function(cli, storageClient, location, affinity
     var storageOptions = {
       name: storageAccountName,
       label: storageAccountName,
-      geoReplicationEnabled: false
+      geoReplicationEnabled: false,
+      accountType: 'Standard_LRS'
     };
 
     if (affinityGroup) {


### PR DESCRIPTION
storageAccounts.create() now expects an accountType parameter.

See http://msdn.microsoft.com/en-us/library/azure/hh264518.aspx